### PR TITLE
fix: request.connection deprecation

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -29,8 +29,8 @@ export class Request extends InteractsWithHeaders {
    */
   getClientIp (): string | undefined {
     return this.fromHeaders() ??
-     this.fromConnection() ??
      this.fromSocket() ??
+     this.fromConnection() ??
      this.fromInfo() ??
      this.fromRaw() ??
      this.fromRequestContext()


### PR DESCRIPTION
This commit reorders the client IP gathering process, prioritising `request.socket` to be accessed before `request.connection`, which is now a deprecated object.

Closes #4 