### PR TITLE
check cf-connecting-ip before x-forwarded-for

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -43,6 +43,11 @@ export class Request extends InteractsWithHeaders {
    */
   fromHeaders (): string | undefined {
     if (this.hasHeaders()) {
+      // Cloudflare
+      if (this.hasIpInHeader('cf-connecting-ip')) {
+        return this.header('cf-connecting-ip')
+      }
+
       // nginx (if configured), load balancers (AWS ELB), and other proxies
       if (this.hasIpInForwardedFor()) {
         return this.getFromForwardedFor()
@@ -56,11 +61,6 @@ export class Request extends InteractsWithHeaders {
       // used by some proxies, like nginx
       if (this.hasIpInHeader('x-real-ip')) {
         return this.header('x-real-ip')
-      }
-
-      // Cloudflare
-      if (this.hasIpInHeader('cf-connecting-ip')) {
-        return this.header('cf-connecting-ip')
       }
 
       // Fastly and Firebase

--- a/test/index.js
+++ b/test/index.js
@@ -245,4 +245,10 @@ describe('Request IP: ', () => {
       RequestIp.getClientIp({ connection: { remoteAddress: '2001:db8::2:1' } })
     ).toEqual('2001:db8::2:1')
   })
+
+  it('cf-connecting-ip and x-forwarded-for', () => {
+    expect(
+      RequestIp.getClientIp({ headers: { 'x-forwarded-for': '8.8.8.8', 'cf-connecting-ip': '4.4.4.4' } })
+    ).toEqual('4.4.4.4')
+  }
 })


### PR DESCRIPTION
Shouldn't the ip address from cloudflare (`cf-connecting-ip`) be more important than `x-forwarded-for`?

My infrastructure looking like this:
Client -> Cloudflare -> Traefik -> Nodejs App
In my scenario Traefik overwrites `x-forwarded-for` and `x-real-ip` to cloudflare servers IP and I can't use it. That's why I think `cf-connecting-ip` is more true than another header.